### PR TITLE
Fix Illegal Op permissions caused by exception

### DIFF
--- a/src/main/java/org/black_ixx/bossshop/core/rewards/BSRewardTypePlayerCommandOp.java
+++ b/src/main/java/org/black_ixx/bossshop/core/rewards/BSRewardTypePlayerCommandOp.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.gradle.internal.impldep.bsh.classpath.ClassManagerImpl;
 
 import java.util.List;
 
@@ -46,9 +47,10 @@ public class BSRewardTypePlayerCommandOp extends BSRewardType {
             try {
                 p.setOp(true);
                 executeCommands(p, buy, commands);
-                p.setOp(false);
             } catch (Exception e) {
+                ClassManager.manager.getBugFinder().severe("Catch an exception while executing opcommands on item " + buy.getName() + "! Please check it. Details:");
                 e.printStackTrace();
+            } finally {
                 p.setOp(false);
             }
         }

--- a/src/main/java/org/black_ixx/bossshop/core/rewards/BSRewardTypePlayerCommandOp.java
+++ b/src/main/java/org/black_ixx/bossshop/core/rewards/BSRewardTypePlayerCommandOp.java
@@ -8,7 +8,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.gradle.internal.impldep.bsh.classpath.ClassManagerImpl;
 
 import java.util.List;
 

--- a/src/main/java/org/black_ixx/bossshop/core/rewards/BSRewardTypePlayerCommandOp.java
+++ b/src/main/java/org/black_ixx/bossshop/core/rewards/BSRewardTypePlayerCommandOp.java
@@ -43,9 +43,14 @@ public class BSRewardTypePlayerCommandOp extends BSRewardType {
         if (p.isOp()) {
             executeCommands(p, buy, commands);
         } else {
-            p.setOp(true);
-            executeCommands(p, buy, commands);
-            p.setOp(false);
+            try {
+                p.setOp(true);
+                executeCommands(p, buy, commands);
+                p.setOp(false);
+            } catch (Exception e) {
+                e.printStackTrace();
+                p.setOp(false);
+            }
         }
 
         if (p.getOpenInventory() != null & !ClassManager.manager.getPlugin().getAPI().isValidShop(p.getOpenInventory())) {


### PR DESCRIPTION
When execute opcommand cause exception, the op permission WON'T be reset.