### PR TITLE
implementing multiple slots through InventoryLocation

### DIFF
--- a/src/main/java/org/black_ixx/bossshop/managers/features/PageLayoutHandler.java
+++ b/src/main/java/org/black_ixx/bossshop/managers/features/PageLayoutHandler.java
@@ -18,9 +18,9 @@ public class PageLayoutHandler {
     @Getter
     private List<BSBuy> items;
     @Getter
-    private int         maxRows = 6; //Default!
-    private int         reservedSlotsStart;
-    private boolean     showIfMultiplePagesOnly;
+    private int maxRows = 6; //Default!
+    private int reservedSlotsStart;
+    private boolean showIfMultiplePagesOnly;
 
     public PageLayoutHandler(List<BSBuy> items, int reservedSlotsStart, boolean showIfMultiplePagesOnly) {
         this.items = items;
@@ -53,13 +53,15 @@ public class PageLayoutHandler {
         reservedSlotsStart = section.getInt("ReservedSlotsStart");
         showIfMultiplePagesOnly = section.getBoolean("ShowIfMultiplePagesOnly");
 
-        items = new ArrayList<BSBuy>();
+        items = new ArrayList<>();
         if (section.isConfigurationSection("items")) {
             for (String key : section.getConfigurationSection("items").getKeys(false)) {
-                BSBuy buy = ClassManager.manager.getBuyItemHandler()
+                List<BSBuy> buyItems = ClassManager.manager.getBuyItemHandler()
                         .loadItem(section.getConfigurationSection("items"), null, key);
-                if (buy != null) {
-                    items.add(buy);
+                for (BSBuy buy : buyItems) {
+                    if (buy != null) {
+                        items.add(buy);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds support for multiple Slots on the "InventoryLocation"-parameter as the following:

Use the parameter as always without impact:
`test-item.InventoryLocation: 3 # Item is set on slot 3`

Use the parameter in a list of integers:
`test-item.InventoryLocation: [2,3,5,6] # Item is set on slots 2,3,5 & 6`

Use the parameter as a stream of integers:
`test-item.InventoryLocation: "2:6" # Fills the slots 2-6 with this item`