### PR TITLE
53 suggestion discount

### DIFF
--- a/src/main/java/org/black_ixx/bossshop/core/BSBuy.java
+++ b/src/main/java/org/black_ixx/bossshop/core/BSBuy.java
@@ -334,7 +334,6 @@ public class BSBuy {
             if(msg.contains("%price_")) {
                 // Get the content between %price_*%,
                 String placeholder = "%price_" + msg.split("%price_")[1].split("%")[0] +"%";
-                Bukkit.getConsoleSender().sendMessage("Placeholder: " + placeholder);
                 // split on '_', check if size is == 3
                 String[] parts = placeholder.split("_");
                 if(parts.length == 3) {

--- a/src/main/java/org/black_ixx/bossshop/core/BSBuy.java
+++ b/src/main/java/org/black_ixx/bossshop/core/BSBuy.java
@@ -10,6 +10,7 @@ import org.black_ixx.bossshop.events.BSPlayerPurchaseEvent;
 import org.black_ixx.bossshop.events.BSPlayerPurchasedEvent;
 import org.black_ixx.bossshop.managers.ClassManager;
 import org.black_ixx.bossshop.managers.config.BSConfigShop;
+import org.black_ixx.bossshop.misc.MathTools;
 import org.black_ixx.bossshop.misc.Misc;
 import org.black_ixx.bossshop.misc.ShopItemPurchaseTask;
 import org.black_ixx.bossshop.settings.Settings;
@@ -289,11 +290,11 @@ public class BSBuy {
         }
 
         // Not working with these variables anymore. They are still included and set to "" in order to make previous shops still look good and stay compatible.
-        if (priceT != null && !Objects.equals(priceT.name(), "") && priceT.name().length() > 0) {
+        if (priceT != null && !Objects.equals(priceT.name(), "") && !priceT.name().isEmpty()) {
             msg = msg.replace(" %pricetype%", "");
             msg = msg.replace("%pricetype%", "");
         }
-        if (rewardT != null && !Objects.equals(rewardT.name(), "") && rewardT.name().length() > 0) {
+        if (rewardT != null && !Objects.equals(rewardT.name(), "") && !rewardT.name().isEmpty()) {
             msg = msg.replace(" %rewardtype%", "");
             msg = msg.replace("%rewardtype%", "");
         }
@@ -301,7 +302,7 @@ public class BSBuy {
         // Handle rest
         msg = msg.replace("%shopitemname%", this.name);
 
-        String name = this.name;
+        String name;
         if (shop != null && item != null) {
             String itemTitle = ClassManager.manager.getItemStackTranslator().readItemName(item);
             if (itemTitle != null) {
@@ -320,6 +321,12 @@ public class BSBuy {
             }
             if (msg.contains("%priceraw%")) {
                 msg = msg.replace("%priceraw%", String.valueOf(price));
+            }
+            if (msg.contains("%original_price%")) {
+                msg = msg.replace("%original_price%", MathTools.displayNumber((double) price, BSPriceType.Money));
+            }
+            if (msg.contains("%original_reward%")) {
+                msg = msg.replace("%original_reward%", MathTools.displayNumber((double) price, BSPriceType.Points));
             }
         }
         return msg;

--- a/src/main/java/org/black_ixx/bossshop/core/BSBuy.java
+++ b/src/main/java/org/black_ixx/bossshop/core/BSBuy.java
@@ -48,6 +48,10 @@ public class BSBuy {
     private Object       reward;
     private Object      price;
     @Getter
+    private String priceMessage = "";
+    @Getter
+    private String rewardMessage = "";
+    @Getter
     private BSCondition condition;
     private String      permission;
     private boolean      permIsGroup = false;
@@ -237,6 +241,8 @@ public class BSBuy {
      * @return transformed message.
      */
     public String transformMessage(String msg, BSShop shop, Player p) {
+        rewardMessage = "";
+        priceMessage = "";
         if (msg == null || msg.isEmpty()) {
             return msg;
         }
@@ -256,11 +262,8 @@ public class BSBuy {
 
         // Handle reward and price variables
         if (msg.contains("%price%") || msg.contains("%reward%")) {
-            String rewardMessage =
-                    rewardT.isPlayerDependend(this, null) ? null : rewardT.getDisplayReward(p, this, reward, null);
-            String priceMessage =
-                    priceT.isPlayerDependend(this, null) ? null : priceT.getDisplayPrice(p, this, price, null);
-
+            rewardMessage = rewardT.isPlayerDependend(this, null) ? null : rewardT.getDisplayReward(p, this, reward, null);
+            priceMessage = priceT.isPlayerDependend(this, null) ? null : priceT.getDisplayPrice(p, this, price, null);
 
             if (shop != null) { // Does shop need to be customizable and is not already?
                 if (!shop.isCustomizable()) {
@@ -327,6 +330,30 @@ public class BSBuy {
             }
             if (msg.contains("%original_reward%")) {
                 msg = msg.replace("%original_reward%", MathTools.displayNumber((double) price, BSPriceType.Points));
+            }
+            if(msg.contains("%price_")) {
+                // Get the content between %price_*%,
+                String placeholder = "%price_" + msg.split("%price_")[1].split("%")[0] +"%";
+                Bukkit.getConsoleSender().sendMessage("Placeholder: " + placeholder);
+                // split on '_', check if size is == 3
+                String[] parts = placeholder.split("_");
+                if(parts.length == 3) {
+                    String shopName = parts[1];
+                    String itemId = parts[2];
+
+                    // Call the bug finder since its not implemented yet
+                    ClassManager.manager.getBugFinder()
+                            .warn(String.format("[%s:%s] We do not have support for placeholders like %s at the moment. This feature is work in progress though!", shop.getShopName(), getName(), placeholder));
+                    // Search the shop with the name and its itemId
+                    /*BSShop _shop = ClassManager.manager.getShops().getShop(shopName);
+                    if(_shop != null) {
+                        BSBuy _buy = _shop.getItem(itemId);
+                        if(_buy != null) {
+                            // Replace the placeholder with the price of the item
+                            msg = msg.replace(placeholder, _buy.priceMessage);
+                        }
+                    }*/
+                }
             }
         }
         return msg;
@@ -594,7 +621,6 @@ public class BSBuy {
         //Update shop if needed
         if (shop.isCustomizable() && needUpdate && event != null) { //'event' is null in case of a simulated click
             if (p.getOpenInventory() == event.getView()) { //only if inventory is still open
-
                 if (async) {
                     Bukkit.getScheduler().runTask(ClassManager.manager.getPlugin(), new Runnable() {
                         @Override
@@ -617,10 +643,7 @@ public class BSBuy {
                             holder.getHighestPage(),
                             false);
                 }
-
             }
         }
-
     }
-
 }

--- a/src/main/java/org/black_ixx/bossshop/core/BSMultiplier.java
+++ b/src/main/java/org/black_ixx/bossshop/core/BSMultiplier.java
@@ -170,8 +170,25 @@ public class BSMultiplier {
         if(shopName == null && itemId == null) {
             return true;
         } else if(shopName != null && itemId == null) {
+            boolean hasShopWildcard = shopName.endsWith("*");
+            if(hasShopWildcard) {
+                // Remove the wildcard character (*) from the shop name and check if the buy shop name starts with the shop name (case insensitive)
+                String wildcardShopName = shopName.substring(0, shopName.length() - 1);
+                return buy.getShop().getShopName().toLowerCase().startsWith(wildcardShopName.toLowerCase());
+            }
             return shopName.equalsIgnoreCase(buy.getShop().getShopName());
         } else if(shopName != null) {
+            boolean hasShopWildcard = shopName.endsWith("*");
+            boolean hasItemWildcard = itemId.endsWith("*");
+            String wildcardShopName = shopName.substring(0, shopName.length() - 1);
+            String wildcardItemId = itemId.substring(0, itemId.length() - 1);
+            if(hasShopWildcard && hasItemWildcard) {
+                return buy.getShop().getShopName().toLowerCase().startsWith(wildcardShopName.toLowerCase()) && buy.getName().toLowerCase().startsWith(wildcardItemId.toLowerCase());
+            } else if(hasShopWildcard) {
+                return buy.getShop().getShopName().toLowerCase().startsWith(wildcardShopName.toLowerCase()) && itemId.equalsIgnoreCase(buy.getName());
+            } else if(hasItemWildcard) {
+                return shopName.equalsIgnoreCase(buy.getShop().getShopName()) && buy.getName().toLowerCase().startsWith(wildcardItemId.toLowerCase());
+            }
             return shopName.equalsIgnoreCase(buy.getShop().getShopName()) && itemId.equalsIgnoreCase(buy.getName());
         }
         return true;

--- a/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeExp.java
+++ b/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeExp.java
@@ -10,7 +10,6 @@ import org.bukkit.event.inventory.ClickType;
 
 public class BSPriceTypeExp extends BSPriceTypeNumber {
 
-
     public Object createObject(Object o, boolean forceFinalState) {
         return InputReader.getInt(o, -1);
     }
@@ -67,12 +66,15 @@ public class BSPriceTypeExp extends BSPriceTypeNumber {
 
     @Override
     public String getDisplayPrice(Player p, BSBuy buy, Object price, ClickType clickType) {
-        return ClassManager.manager.getMultiplierHandler()
+        // TODO might need a better handling in future. I think we could skip a lot of the 'calculatePriceDisplayWithMultiplier' depth
+        String newExp = ClassManager.manager.getMultiplierHandler()
                 .calculatePriceDisplayWithMultiplier(p,
                         buy,
                         clickType,
                         (Integer) price,
                         ClassManager.manager.getMessageHandler().get("Display.Exp").replace("%levels%", "%number%"));
+        double oldExp = (double) buy.getReward(clickType);
+        return BSPriceTypeMoney.getRenewedFormat(newExp, MathTools.displayNumber(oldExp, MathTools.getFormatting(this), isIntegerValue()));
     }
 
 

--- a/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeMoney.java
+++ b/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeMoney.java
@@ -1,15 +1,16 @@
 package org.black_ixx.bossshop.core.prices;
 
-
 import org.black_ixx.bossshop.core.BSBuy;
 import org.black_ixx.bossshop.managers.ClassManager;
 import org.black_ixx.bossshop.managers.misc.InputReader;
 import org.black_ixx.bossshop.misc.MathTools;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 
 public class BSPriceTypeMoney extends BSPriceTypeNumber {
 
+    public static String renewedFormat = ClassManager.manager.getPlugin().getConfig().getString("MultiplierGroups.RenewedPriceFormat");
 
     public Object createObject(Object o, boolean forceFinalState) {
         return InputReader.getDouble(o, -1);
@@ -30,6 +31,11 @@ public class BSPriceTypeMoney extends BSPriceTypeNumber {
         ClassManager.manager.getSettings().setVaultEnabled(true);
     }
 
+    public static String getRenewedFormat(String newValue, String oldValue) {
+        String reducedOldPrice = MathTools.removeNonNumeric(oldValue);
+        String reducedNewPrice = MathTools.removeNonNumeric(newValue);
+        return reducedNewPrice.equals(reducedOldPrice) ? newValue : renewedFormat.replace("%oldValue%", oldValue).replace("%newValue%", newValue);
+    }
 
     @Override
     public boolean hasPrice(Player p,
@@ -64,7 +70,7 @@ public class BSPriceTypeMoney extends BSPriceTypeNumber {
 
     @Override
     public String takePrice(Player p, BSBuy buy, Object price, ClickType clickType, int multiplier) {
-        double money = (double) ClassManager.manager.getMultiplierHandler()
+        double money = ClassManager.manager.getMultiplierHandler()
                 .calculatePriceWithMultiplier(p, buy, clickType, (Double) price) * multiplier;
 
         if (!ClassManager.manager.getVaultHandler().getEconomy().hasAccount(p.getName())) {
@@ -87,12 +93,14 @@ public class BSPriceTypeMoney extends BSPriceTypeNumber {
 
     @Override
     public String getDisplayPrice(Player p, BSBuy buy, Object price, ClickType clickType) {
-        return ClassManager.manager.getMultiplierHandler()
-                .calculatePriceDisplayWithMultiplier(p,
+        // TODO might need a better handling in future. I think we could skip a lot of the 'calculatePriceDisplayWithMultiplier' depth
+        String newPrice = ClassManager.manager.getMultiplierHandler().calculatePriceDisplayWithMultiplier(p,
                         buy,
                         clickType,
                         (Double) price,
                         ClassManager.manager.getMessageHandler().get("Display.Money").replace("%money%", "%number%"));
+        double oldPrice = (double) buy.getPrice(clickType);
+        return getRenewedFormat(newPrice, MathTools.displayNumber(oldPrice, MathTools.getFormatting(this), isIntegerValue()));
     }
 
     @Override

--- a/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeMoney.java
+++ b/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeMoney.java
@@ -33,7 +33,7 @@ public class BSPriceTypeMoney extends BSPriceTypeNumber {
     public static String getRenewedFormat(String newValue, String oldValue) {
         String reducedOldPrice = MathTools.removeNonNumeric(oldValue);
         String reducedNewPrice = MathTools.removeNonNumeric(newValue);
-        return reducedNewPrice.equals(reducedOldPrice) ? newValue : renewedFormat.replace("%oldValue%", oldValue).replace("%newValue%", newValue);
+        return reducedNewPrice.equals(reducedOldPrice) ? newValue : renewedFormat.replace("%oldValue%", newValue.replace(reducedNewPrice, reducedOldPrice)).replace("%newValue%", newValue);
     }
 
     @Override

--- a/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeMoney.java
+++ b/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypeMoney.java
@@ -4,7 +4,6 @@ import org.black_ixx.bossshop.core.BSBuy;
 import org.black_ixx.bossshop.managers.ClassManager;
 import org.black_ixx.bossshop.managers.misc.InputReader;
 import org.black_ixx.bossshop.misc.MathTools;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 
@@ -44,7 +43,7 @@ public class BSPriceTypeMoney extends BSPriceTypeNumber {
                             ClickType clickType,
                             int multiplier,
                             boolean messageOnFailure) {
-        double money = (double) ClassManager.manager.getMultiplierHandler()
+        double money = ClassManager.manager.getMultiplierHandler()
                 .calculatePriceWithMultiplier(p, buy, clickType, (Double) price) * multiplier;
         if (ClassManager.manager.getVaultHandler() == null) {
             return false;

--- a/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypePoints.java
+++ b/src/main/java/org/black_ixx/bossshop/core/prices/BSPriceTypePoints.java
@@ -67,12 +67,14 @@ public class BSPriceTypePoints extends BSPriceTypeNumber {
 
     @Override
     public String getDisplayPrice(Player p, BSBuy buy, Object price, ClickType clickType) {
-        return ClassManager.manager.getMultiplierHandler()
+        String newPoints = ClassManager.manager.getMultiplierHandler()
                 .calculatePriceDisplayWithMultiplier(p,
                         buy,
                         clickType,
                         (Double) price,
                         ClassManager.manager.getMessageHandler().get("Display.Points").replace("%points%", "%number%"));
+        double oldPoints = (double) buy.getPrice(clickType);
+        return BSPriceTypeMoney.getRenewedFormat(newPoints, MathTools.displayNumber(oldPoints, MathTools.getFormatting(this), isIntegerValue()));
     }
 
 

--- a/src/main/java/org/black_ixx/bossshop/managers/features/MultiplierHandler.java
+++ b/src/main/java/org/black_ixx/bossshop/managers/features/MultiplierHandler.java
@@ -174,11 +174,6 @@ public class MultiplierHandler {
 
 
     public boolean hasMultipliers() {
-        if (multipliers == null) {
-            return false;
-        }
         return !multipliers.isEmpty();
     }
-
-
 }

--- a/src/main/java/org/black_ixx/bossshop/managers/features/MultiplierHandler.java
+++ b/src/main/java/org/black_ixx/bossshop/managers/features/MultiplierHandler.java
@@ -1,5 +1,6 @@
 package org.black_ixx.bossshop.managers.features;
 
+import lombok.Getter;
 import org.black_ixx.bossshop.BossShop;
 import org.black_ixx.bossshop.core.BSBuy;
 import org.black_ixx.bossshop.core.BSMultiplier;
@@ -16,24 +17,24 @@ import java.util.List;
 import java.util.Set;
 
 
+@Getter
 public class MultiplierHandler {
 
-    private Set<BSMultiplier> multipliers = new HashSet<BSMultiplier>();
+    private final Set<BSMultiplier> multipliers = new HashSet<>();
 
+    private BossShop plugin;
+    private List<String> lines;
     public MultiplierHandler(BossShop plugin) {
-        if (plugin.getConfig().getBoolean("MultiplierGroups.Enabled") == false) {
+        if (!plugin.getConfig().getBoolean("MultiplierGroups.Enabled")) {
             return;
         }
-        List<String> lines = plugin.getConfig().getStringList("MultiplierGroups.List");
-        if (lines == null) {
-            return;
-        }
-        setup(plugin, lines);
+        lines = plugin.getConfig().getStringList("MultiplierGroups.List");
+        setup();
     }
 
-    public void setup(BossShop plugin, List<String> configLines) {
+    public void setup() {
         multipliers.clear();
-        for (String s : configLines) {
+        for (String s : lines) {
             BSMultiplier m = new BSMultiplier(s);
             if (m.isValid()) {
                 multipliers.add(m);
@@ -68,8 +69,8 @@ public class MultiplierHandler {
 
         if (buy.getRewardType(clickType) == BSRewardType.ItemAll) {
             if (ClassManager.manager.getSettings().getItemAllShowFinalReward() && p != null) {
-                ItemStack i     = (ItemStack) buy.getReward(clickType);
-                int       count = ClassManager.manager.getItemStackChecker().getAmountOfFreeSpace(p, i);
+                ItemStack i = (ItemStack) buy.getReward(clickType);
+                int count = ClassManager.manager.getItemStackChecker().getAmountOfFreeSpace(p, i);
 
                 if (count == 0) {
                     return ClassManager.manager.getMessageHandler()
@@ -91,12 +92,14 @@ public class MultiplierHandler {
     }
 
     public double calculatePriceWithMultiplier(Player p, BSBuy buy, ClickType clickType, double d) {
-        return calculatePriceWithMultiplier(p, buy.getPriceType(clickType), d);
+        return calculatePriceWithMultiplier(p, buy, buy.getPriceType(clickType), d);
     }
 
-    public double calculatePriceWithMultiplier(Player p, BSPriceType priceType, double d) { //Used for prices
+    public double calculatePriceWithMultiplier(Player p, BSBuy buy, BSPriceType priceType, double d) { //Used for prices
         for (BSMultiplier m : multipliers) {
-            d = m.calculateValue(p, priceType, d, BSMultiplier.RANGE_PRICE_ONLY);
+            if(m.isAcceptedShopItem(buy)) {
+                d = m.calculateValue(p, priceType, d, BSMultiplier.RANGE_PRICE_ONLY);
+            }
         }
         return MathTools.round(d, 2);
     }
@@ -128,8 +131,8 @@ public class MultiplierHandler {
 
         if (buy.getPriceType(clickType) == BSPriceType.ItemAll) {
             if (ClassManager.manager.getSettings().getItemAllShowFinalReward() && p != null) {
-                ItemStack i     = (ItemStack) buy.getPrice(clickType);
-                int       count = ClassManager.manager.getItemStackChecker().getAmountOfSameItems(p, i, buy);
+                ItemStack i = (ItemStack) buy.getPrice(clickType);
+                int count = ClassManager.manager.getItemStackChecker().getAmountOfSameItems(p, i, buy);
 
                 if (count == 0) {
                     return ClassManager.manager.getMessageHandler()
@@ -154,22 +157,21 @@ public class MultiplierHandler {
                                                 BSBuy buy,
                                                 ClickType clickType,
                                                 double d) { //Used for reward; Works the other way around
-        return calculateRewardWithMultiplier(p, buy.getRewardType(clickType), d);
+        return calculateRewardWithMultiplier(p, buy, buy.getRewardType(clickType), d);
     }
 
     public double calculateRewardWithMultiplier(Player p,
+                                                BSBuy buy,
                                                 BSRewardType rewardtype,
                                                 double d) { //Used for reward; Works the other way around
         for (BSMultiplier m : multipliers) {
-            d = m.calculateValue(p, BSPriceType.detectType(rewardtype.name()), d, BSMultiplier.RANGE_REWARD_ONLY);
+            if(m.isAcceptedShopItem(buy)) {
+                d = m.calculateValue(p, BSPriceType.detectType(rewardtype.name()), d, BSMultiplier.RANGE_REWARD_ONLY);
+            }
         }
         return MathTools.round(d, 2);
     }
 
-
-    public Set<BSMultiplier> getMultipliers() {
-        return multipliers;
-    }
 
     public boolean hasMultipliers() {
         if (multipliers == null) {

--- a/src/main/java/org/black_ixx/bossshop/misc/MathTools.java
+++ b/src/main/java/org/black_ixx/bossshop/misc/MathTools.java
@@ -66,6 +66,9 @@ public class MathTools {
         return s;
     }
 
+    public static String removeNonNumeric(String str) {
+        return str.replaceAll("[^\\d.]", "");
+    }
 
     public static double round(double value, int places) {
         if (places < 0) throw new IllegalArgumentException();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -223,16 +223,21 @@ BungeeCord : false
 # MultiplierGroups:
 # Here you can set up Price Multipliers.
 # If enabled, this MultiplierGroups will be loaded and players with the right permissions will get a price decrease/increase.
-# The lines of the List look like this: <Permission>:<Type>:<Multiplier>:<buy/sell/both>.
+# The lines of the List look like this: <Permission>:<Type>:<Multiplier>:<price/reward/both>:[shop]:[itemId].
 # <Permission>: Here you can put in whatever you want. If you want a group to have this multiplier, just give that group your permission.
 # <Type>: Multiplier Type. Valid: Money, Points, Exp
 # <Multiplier>: Price = old Price * Multiplier
 # <price/reward/both>: Here you enter the range of the multiplier. It can affect either prices, rewards or both. If using prices or rewards the value is multiplied by the multiplier.
 # In case of using range "both" the prices are multiplied by the given multiplier and the rewards are divided by the given multiplier. If you do not define a range the plugin will automatically select "both".
+# [shop]: Here you can define the shop the multiplier should be applied to. If you do not define a shop the plugin will select all shops.
+# [itemId]: Here you can define the item the multiplier should be applied to. If you do not define an item the plugin will select all items of the shop.
+# The modified price-format is shown in 'RenewedPriceFormat', showing %oldValue% as the old price and %newValue% as the new price.
 # Players can be in multiple "MultiplierGroups" at the same time.
 MultiplierGroups:
   Enabled: false
+  RenewedPriceFormat: "&c&m%oldValue%&r &r&a%newValue%&r"
   List:
+  - BossShop.PriceMultiplier.SpecialShopTest:money:0.1:price:test-shop:test-item
   - BossShop.PriceMultiplier.Points:points:0.75:price
   - BossShop.PriceMultiplier.Money:money:0.5:price
   - BossShop.RewardMultiplier.Money:money:2.0:reward

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -231,6 +231,7 @@ BungeeCord : false
 # In case of using range "both" the prices are multiplied by the given multiplier and the rewards are divided by the given multiplier. If you do not define a range the plugin will automatically select "both".
 # [shop]: Here you can define the shop the multiplier should be applied to. If you do not define a shop the plugin will select all shops.
 # [itemId]: Here you can define the item the multiplier should be applied to. If you do not define an item the plugin will select all items of the shop.
+# Both, [shop] and [itemId] allow wildcards at the end. Like "block*" on itemId for example would multiply all items that start with "block". Using "admin*" would multiply all shops that start with "admin".
 # The modified price-format is shown in 'RenewedPriceFormat', showing %oldValue% as the old price and %newValue% as the new price.
 # Players can be in multiple "MultiplierGroups" at the same time.
 MultiplierGroups:


### PR DESCRIPTION
Since we have a multiplier mechanic for permissions, I extended it to be applicable on single shops and event items of a shop. Those work like the following:
```
# MultiplierGroups:
# Here you can set up Price Multipliers.
# If enabled, this MultiplierGroups will be loaded and players with the right permissions will get a price decrease/increase.
# The lines of the List look like this: <Permission>:<Type>:<Multiplier>:<price/reward/both>:[shop]:[itemId].
# <Permission>: Here you can put in whatever you want. If you want a group to have this multiplier, just give that group your permission.
# <Type>: Multiplier Type. Valid: Money, Points, Exp
# <Multiplier>: Price = old Price * Multiplier
# <price/reward/both>: Here you enter the range of the multiplier. It can affect either prices, rewards or both. If using prices or rewards the value is multiplied by the multiplier.
# In case of using range "both" the prices are multiplied by the given multiplier and the rewards are divided by the given multiplier. If you do not define a range the plugin will automatically select "both".
# [shop]: Here you can define the shop the multiplier should be applied to. If you do not define a shop the plugin will select all shops.
# [itemId]: Here you can define the item the multiplier should be applied to. If you do not define an item the plugin will select all items of the shop.
# The modified price-format is shown in 'RenewedPriceFormat', showing %oldValue% as the old price and %newValue% as the new price.
# Players can be in multiple "MultiplierGroups" at the same time.
MultiplierGroups:
  Enabled: false
  RenewedPriceFormat: "&c&m%oldValue%&r &r&a%newValue%&r"
  List:
  - BossShop.PriceMultiplier.Points:points:0.75:price # Untouched
  - BossShop.PriceMultiplier.Money:money:0.5:price # Untouched
  - BossShop.RewardMultiplier.Money:money:2.0:reward # Untouched
  - BossShop.BothMultiplier.Exp:exp:0.8 # Untouched
  - BossShop.PriceMultiplier.SpecialShopTest:money:0.1:price:test-shop:test-item # Multiplies item "test-item" in shop "test-shop"
  - BossShop.PriceMultiplier.SpecialShopTest:money:0.1:price:test-shop # Multiplies all items of "test-shop"
  - BossShop.PriceMultiplier.SpecialShopTest:money:0.1:price:shop*:test* # Multiplies items that start with "test" wildcard inside of shops with "shop" wildcards
```

Summed up:

- Implemented possibility to make prices dynamically for single shops (wildcard at the end supported)
- Implemented possibility to make prices dynamically for single items of shops (wildcard at the end supported)
- Implemented the 'RenewedPriceFormat' value in config.yml that provides a before-after compare of the price
- Implemented the '%original_price%' placeholder to give the price before it was multiplied (else the standard)

What's missing:
- We cannot make a placeholder through different shops like '%price_[shop]_[item]%' yet, because the way we load BSP does not allow it at the moment. The logic itself is implemented as much as possible until we have a solution (see  BSBuy.class line 344)