### PR TITLE
Load shops in sub-directories inside sub-directories

### DIFF
--- a/src/main/java/studio/magemonkey/genesis/core/GenesisShops.java
+++ b/src/main/java/studio/magemonkey/genesis/core/GenesisShops.java
@@ -36,27 +36,21 @@ public class GenesisShops {
 
     private boolean loadShops(File folder, Settings settings, String parentPath) {
         boolean enableShopCommands = false;
-
+    
         for (File f : folder.listFiles()) {
             if (f != null) {
                 if (f.isDirectory()) {
                     if (settings.getLoadSubFoldersEnabled()) {
-                        if (loadShops(f, settings, f.getName() + File.separator)) {
+                        if (loadShops(f, settings, parentPath + f.getName() + File.separator)) {
                             enableShopCommands = true;
                         }
                     }
-                    continue;
-                }
-
-                if (f.isFile()) {
-                    if (f.getName().contains(".yml")) {
-                        GenesisShop shop = loadShop(f, parentPath);
-
-                        if (shop.getCommands() != null) {
-                            enableShopCommands = true;
-                        }
+                } else if (f.isFile() && f.getName().endsWith(".yml")) {
+                    GenesisShop shop = loadShop(f, parentPath);
+    
+                    if (shop.getCommands() != null) {
+                        enableShopCommands = true;
                     }
-
                 }
             }
         }


### PR DESCRIPTION
Using `SearchSubfoldersForShops: true` we are able to create shops inside directories, but we can't create directories inside directories and load the shops inside it. That's bad for the servers with a lot of shops (I have over 250 shops so can be a pretty mess).

This simple commit fix the problem above, making the possibility to create infinity amount of sub-directories inside another directories and load all shops without any problem. Shops with the same name in diffents directories still works as normally and all works correctly.

